### PR TITLE
Fix: 네비게이션 Back Button 커스텀하여 적용 #4

### DIFF
--- a/Pairing/Sources/Views/EnvironmentAnalysis/EnvironmentAnalysis.swift
+++ b/Pairing/Sources/Views/EnvironmentAnalysis/EnvironmentAnalysis.swift
@@ -10,8 +10,23 @@ import SwiftUI
 // MARK: - 환경 분석 화면
 
 struct EnvironmentAnalysis: View {
+    
+    @Environment(\.presentationMode) var presentationMode
+    
+    // 커스텀한 Back button
+    var backButton: some View {
+        Button(action: {
+            presentationMode.wrappedValue.dismiss() // 이전 화면으로 돌아가기
+        }) {
+            Image(systemName: "chevron.backward") // 뒤로가기 아이콘
+                .foregroundColor(.black)
+        }
+    }
+    
     var body: some View {
         Text("Environment Analysis")
+            .navigationBarBackButtonHidden(true) // 기본 Back Button 숨김
+            .navigationBarItems(leading: backButton) // 커스텀 Back Button 추가
     }
 }
 

--- a/Pairing/Sources/Views/RealTimeScripts/PreRecordingView.swift
+++ b/Pairing/Sources/Views/RealTimeScripts/PreRecordingView.swift
@@ -8,10 +8,24 @@
 import SwiftUI
 
 struct PreRecordingView: View {
+    
+    @Environment(\.presentationMode) var presentationMode
+    
+    // 커스텀한 Back button
+    var backButton: some View {
+        Button(action: {
+            presentationMode.wrappedValue.dismiss() // 이전 화면으로 돌아가기
+        }) {
+            Image(systemName: "chevron.backward") // 뒤로가기 아이콘
+                .foregroundColor(.black)
+        }
+    }
+    
     var body: some View {
         NavigationView {
             ZStack {
                 Image("RealTimeScriptBackground")
+                    .edgesIgnoringSafeArea(.all)
                 
                 VStack {
                     Spacer()
@@ -61,6 +75,8 @@ struct PreRecordingView: View {
                 } // VStack
             }
         } // ZStack
+        .navigationBarBackButtonHidden(true) // 기본 Back Button 숨김
+        .navigationBarItems(leading: backButton) // 커스텀 Back Button 추가
     } // body
 }
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정
## 📄 개요
- 원래 있던 네비게이션 기본 Back Button을 숨기고 커스텀 한 버튼으로 적용
## 🔁 변경 사항
[Fix: 네비게이션 Back Button 커스텀하여 적용](https://github.com/GraduationProject-Team4/Pairing-iOS/commit/d83787823716bed9e4407ffe4d83c8f0ba6bf466)
## 📸 스크린샷 
![스크린샷 2023-07-28 오전 1 46 46](https://github.com/GraduationProject-Team4/Pairing-iOS/assets/87434861/d5001b89-3dcd-4d43-9bf9-254cee200475)
![스크린샷 2023-07-28 오전 1 47 01](https://github.com/GraduationProject-Team4/Pairing-iOS/assets/87434861/3bb70fad-2710-423a-be6c-3f95c77f43c2)