### PR TITLE
Feat: 주변 환경음 분석 결과 화면과 화면 전환 연결

### DIFF
--- a/Pairing/Sources/Views/EnvironmentAnalysis/AnalysisResultView.swift
+++ b/Pairing/Sources/Views/EnvironmentAnalysis/AnalysisResultView.swift
@@ -13,9 +13,12 @@ struct AnalysisResultView: View {
     
     // MARK: - Properties
     
+    @Environment(\.presentationMode) var presentationMode
+    
     @State private var pinOffset: CGFloat = 0
     @State private var pinCurrentLocation: CGFloat = 0
     @State private var alertDecibel: CGFloat = 0
+    @State private var showNextScreen: Bool = false
     
     var averageDecibel = 60
     var maxDecibel = 150
@@ -27,123 +30,145 @@ struct AnalysisResultView: View {
         Sound(name: "사이렌", image: Image(systemName: "light.beacon.min.fill"))
     ]
     
+    // 커스텀한 Back button
+    var backButton: some View {
+        Button(action: {
+            presentationMode.wrappedValue.dismiss() // 이전 화면으로 돌아가기
+        }) {
+            Image(systemName: "chevron.backward") // 뒤로가기 아이콘
+                .foregroundColor(.black)
+        }
+    }
+    
     // MARK: - Body
     
     var body: some View {
-        ZStack {
-            Image("EnviromentBackground")
-            
-            VStack {
-                Spacer()
+        NavigationView {
+            ZStack {
+                Image("EnviromentBackground")
                 
-                VStack(spacing: 15) {
-                    Text("지금 내 주위의 소리는 🤔\n평균적으로 \(averageDecibel)dB, 최대 \(maxDecibel)dB")
-                        .font(.system(size: 26))
-                        .fontWeight(.bold)
-                        .frame(width: 340, alignment: .leading)
+                VStack {
+                    Spacer()
                     
-                    Text("이 곳에서는 이런 소리들이 들려요!")
-                        .frame(width: 340, alignment: .leading)
-                        .foregroundColor(.gray)
-                        .font(.system(size: 15))
-                    
-                    ScrollView() {
-                        Spacer()
-                        VStack(spacing: 10) {
-                            ForEach(sounds) { sound in
-                                VStack {
-                                    SoundCell(name: sound.name, image: sound.image)
+                    VStack(spacing: 15) {
+                        Text("지금 내 주위의 소리는 🤔\n평균적으로 \(averageDecibel)dB, 최대 \(maxDecibel)dB")
+                            .font(.system(size: 26))
+                            .fontWeight(.bold)
+                            .frame(width: 340, alignment: .leading)
+                        
+                        Text("이 곳에서는 이런 소리들이 들려요!")
+                            .frame(width: 340, alignment: .leading)
+                            .foregroundColor(.gray)
+                            .font(.system(size: 15))
+                        
+                        ScrollView() {
+                            Spacer()
+                            VStack(spacing: 10) {
+                                ForEach(sounds) { sound in
+                                    VStack {
+                                        SoundCell(name: sound.name, image: sound.image)
+                                    }
                                 }
-                            }
-                            .frame(width: 340, height: 60)
-                        } //: VStack
-                        Spacer(minLength: 16)
-                    } //: Scroll
-                    .frame(width: 400, height: 250)
-                    .padding(.bottom, 30)
-                    
-                    ZStack {
+                                .frame(width: 340, height: 60)
+                            } //: VStack
+                            Spacer(minLength: 16)
+                        } //: Scroll
+                        .frame(width: 400, height: 250)
+                        .padding(.bottom, 30)
+                        
                         ZStack {
-                            Rectangle()
-                                .frame(width: 320, height: 5)
-                                .foregroundColor(Color("Purple03"))
-                                .cornerRadius(20)
-                            
-                            VStack(spacing: 0) {
-                                Text("60db")
-                                    .font(.system(size: 12))
-                                
+                            ZStack {
                                 Rectangle()
-                                    .frame(width: 1, height: 30)
-                            } //: VStack
-                            .position(CGPoint(x: 70, y: 23))
-                            .foregroundColor(Color("Purple02"))
-                            
-                            VStack(spacing: 0) {
-                                Text("120db")
-                                    .font(.system(size: 12))
+                                    .frame(width: 320, height: 5)
+                                    .foregroundColor(Color("Purple03"))
+                                    .cornerRadius(20)
                                 
-                                Rectangle()
-                                    .frame(width: 1, height: 30)
-                            } //: VStack
-                            .position(CGPoint(x: 170, y: 23))
-                            .foregroundColor(Color("Purple02"))
-                            
-                            VStack(spacing: 0) {
-                                Text("180db")
-                                    .font(.system(size: 12))
+                                VStack(spacing: 0) {
+                                    Text("60db")
+                                        .font(.system(size: 12))
+                                    
+                                    Rectangle()
+                                        .frame(width: 1, height: 30)
+                                } //: VStack
+                                .position(CGPoint(x: 70, y: 23))
+                                .foregroundColor(Color("Purple02"))
                                 
-                                Rectangle()
-                                    .frame(width: 1, height: 30)
-                            } //: VStack
-                            .position(CGPoint(x: 270, y: 23))
-                            .foregroundColor(Color("Purple02"))
-                            
-                            Image("decibelPin")
-                                .position(CGPoint(x: pinOffset, y: 10))
-                                .gesture(
-                                    DragGesture()
-                                        .onChanged { gesture in
-                                            // TODO: alertDecibel 식 수정하기
-                                            pinOffset = gesture.translation.width + pinCurrentLocation
-                                            alertDecibel = pinOffset
-                                        }
-                                        .onEnded { gesture in
-                                            pinCurrentLocation = pinOffset
-                                        }
-                                ) //: Gesture
+                                VStack(spacing: 0) {
+                                    Text("120db")
+                                        .font(.system(size: 12))
+                                    
+                                    Rectangle()
+                                        .frame(width: 1, height: 30)
+                                } //: VStack
+                                .position(CGPoint(x: 170, y: 23))
+                                .foregroundColor(Color("Purple02"))
+                                
+                                VStack(spacing: 0) {
+                                    Text("180db")
+                                        .font(.system(size: 12))
+                                    
+                                    Rectangle()
+                                        .frame(width: 1, height: 30)
+                                } //: VStack
+                                .position(CGPoint(x: 270, y: 23))
+                                .foregroundColor(Color("Purple02"))
+                                
+                                Image("decibelPin")
+                                    .position(CGPoint(x: pinOffset, y: 10))
+                                    .gesture(
+                                        DragGesture()
+                                            .onChanged { gesture in
+                                                // TODO: alertDecibel 식 수정하기
+                                                pinOffset = gesture.translation.width + pinCurrentLocation
+                                                alertDecibel = pinOffset
+                                            }
+                                            .onEnded { gesture in
+                                                pinCurrentLocation = pinOffset
+                                            }
+                                    ) //: Gesture
+                            } //: ZStack
                         } //: ZStack
-                    } //: ZStack
-                    .frame(width: 320, height: 60, alignment: .center)
-                    
-                    Text("지금 설정한 데시벨은 \(Int(alertDecibel)) 데시벨이고,\n\(Int(alertDecibel)) 데시벨 수준의 대표적인 소리는 \(representSound)이 있어요!")
-                        .frame(width: 340, height: 50)
-                        .foregroundColor(.gray)
-                        .font(.system(size: 15))
-                        .multilineTextAlignment(.center)
-                    
-                    Button("150 데시벨 이상이 되면 알림을 받을래요") {}
-                        .font(.system(size: 15))
-                        .fontWeight(.semibold)
-                        .frame(width: 370, height: 48)
-                        .background(Color("Purple03"))
-                        .foregroundColor(Color.white)
-                        .cornerRadius(8)
-                    
-                    Button("실시간 알림은 받고싶지 않아요") {}
-                        .font(.system(size: 15))
-                        .fontWeight(.semibold)
-                        .frame(width: 370, height: 30)
-                        .foregroundColor(Color("Purple02"))
+                        .frame(width: 320, height: 60, alignment: .center)
+                        
+                        Text("지금 설정한 데시벨은 \(Int(alertDecibel)) 데시벨이고,\n\(Int(alertDecibel)) 데시벨 수준의 대표적인 소리는 \(representSound)이 있어요!")
+                            .frame(width: 340, height: 50)
+                            .foregroundColor(.gray)
+                            .font(.system(size: 15))
+                            .multilineTextAlignment(.center)
+                        
+                        Button {
+                            self.showNextScreen.toggle()
+                        } label: {
+                            Text("150 데시벨 이상이 되면 알림을 받을래요")
+                                .font(.system(size: 15))
+                                .fontWeight(.semibold)
+                                .frame(width: 370, height: 48)
+                                .background(Color("Purple03"))
+                                .foregroundColor(Color.white)
+                                .cornerRadius(8)
+                        }
+                        
+                        Button("실시간 알림은 받고싶지 않아요") {}
+                            .font(.system(size: 15))
+                            .fontWeight(.semibold)
+                            .frame(width: 370, height: 30)
+                            .foregroundColor(Color("Purple02"))
+                    } // VStack
+                    .padding(.horizontal, 40)
+                    .padding(.top, 50)
+                    .padding(.bottom, 80)
+                    .background(Color("Gray01"))
+                    .cornerRadius(70)
                 } // VStack
-                .padding(.horizontal, 40)
-                .padding(.top, 50)
-                .padding(.bottom, 80)
-                .background(Color("Gray01"))
-                .cornerRadius(70)
-            } // VStack
-        } // ZStack
+                
+                NavigationLink(destination: EnvRecordingView(beforeEnvReport: false), isActive: $showNextScreen) { EmptyView() }
+            } // ZStack
+        }
+        .navigationBarBackButtonHidden(true) // 기본 Back Button 숨김
+        .navigationBarItems(leading: backButton) // 커스텀 Back Button 추가
     } //: Body
+    
+    
 }
 
 // MARK: - Preview

--- a/Pairing/Sources/Views/EnvironmentAnalysis/EnvRecordingView.swift
+++ b/Pairing/Sources/Views/EnvironmentAnalysis/EnvRecordingView.swift
@@ -13,6 +13,7 @@ struct EnvRecordingView: View {
     
     @Environment(\.presentationMode) var presentationMode
     @State public var beforeEnvReport: Bool
+    @State private var showNextScreen: Bool = false
     
     var body: some View {
         NavigationView {
@@ -54,9 +55,22 @@ struct EnvRecordingView: View {
                     .opacity(0.6)
                     .bold()
                 } // VStack
+                
+                NavigationLink(destination: AnalysisResultView(), isActive: $showNextScreen) { EmptyView() }
             } // ZStack
         } // Navi
         .navigationBarBackButtonHidden(true) // 기본 Back Button 숨김
+        .onAppear {
+            if beforeEnvReport {
+                // 3초 후에 runDelayedFunction() 함수를 실행합니다.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                    self.showNextScreen.toggle()
+                    print("EEE")
+                }
+            }
+            
+            // TODO: - 특정 데시벨 이상의 소리를 감지했을 때 경고창 화면으로 전환하는 기능 추가
+        }
     }
 }
 

--- a/Pairing/Sources/Views/Home/HomeView.swift
+++ b/Pairing/Sources/Views/Home/HomeView.swift
@@ -11,10 +11,21 @@ import SwiftUI
 
 struct HomeView: View {
     
+    @Environment(\.presentationMode) var presentationMode
+    // 커스텀한 Back button
+    var backButton: some View {
+        Button(action: {
+            presentationMode.wrappedValue.dismiss() // 이전 화면으로 돌아가기
+        }) {
+            Image(systemName: "chevron.backward") // 뒤로가기 아이콘
+                .foregroundColor(.black)
+        }
+    }
+    
     // MARK: - Body
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView(.vertical, showsIndicators: false) {
                 ZStack {
                     Image("HomeBackground")
@@ -36,6 +47,8 @@ struct HomeView: View {
             } //: Scroll
             .edgesIgnoringSafeArea(.all)
         }
+        .navigationBarBackButtonHidden(true) // 기본 Back Button 숨김
+        .navigationBarItems(leading: backButton) // 커스텀 Back Button 추가
     }
 }
 


### PR DESCRIPTION
#7

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정
## 📄 개요
- 내가 맡았던 화면 3개(경고 화면 제외)와 주변 환경음 분석 결과 화면 간의 화면 전환 구현
-> 특정 데시벨 이상의 소리를 감지했을 때 경고창 화면으로 전환하는 기능은 추후 구현 예정
- 일단 3초 뒤에 분석 결과 화면으로 넘어가도록 해놓음
## 🔁 변경 사항
[Feat: 주변 환경음 분석 결과 화면과 화면 전환 연결](https://github.com/GraduationProject-Team4/Pairing-iOS/pull/13/commits/75e3860e3555b4dc1b1af55ff252a4ed5751299b)
## 👀 기타 더 이야기해볼 점
- 데시벨 관련 식은 이거 머지 받으시고 진행하면 될 듯 하옵니다